### PR TITLE
Updated ecstatic to version 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "babelify": "^6.1.3",
     "browserify": "^10.2.6",
-    "ecstatic": "1.1.1",
+    "ecstatic": "1.1.3",
     "es6-promise": "^3.0.2",
     "isomorphic-fetch": "^2.1.1",
     "react": "~0.13.3",


### PR DESCRIPTION
:rocket:

ecstatic just published version 1.1.3, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 8 commits (ahead by 8, behind by 0).

- [3102858](https://github.com/jfhbrook/node-ecstatic/commit/3102858ac2190a059ad4bf4ede888da092ce9c90): Release 1.1.3
- [dd62194](https://github.com/jfhbrook/node-ecstatic/commit/dd621942f5c8562a99ed268701260e688944c7b6): Merge pull request #162 from substack/cors-boolean-fix
- [e48e077](https://github.com/jfhbrook/node-ecstatic/commit/e48e0779decab428303ee603364c1255233a59c4): set cors to false to enable booleanism on the command-line
- [3a7d2e6](https://github.com/jfhbrook/node-ecstatic/commit/3a7d2e67b58e268cc2835eb8ab74f90f88b97c2f): Release 1.1.2
- [061c423](https://github.com/jfhbrook/node-ecstatic/commit/061c42310a295c6406c169cda7ff13150044ab36): Merge pull request #161 from substack/boolean
- [77d9a7d](https://github.com/jfhbrook/node-ecstatic/commit/77d9a7d212ee1f69b3a1517c90aa9860eb4c7240): fix for options handler from --cors to not get unset
- [3fd60d6](https://github.com/jfhbrook/node-ecstatic/commit/3fd60d6f5b2171f53ac0e6dfa723420b4738760a): require the correct file
- [59e63bf](https://github.com/jfhbrook/node-ecstatic/commit/59e63bfc3102188a3945712158775b8e027c3ae2): share defaults and aliases between opts handler and minimist

See the [full diff](https://github.com/jfhbrook/node-ecstatic/compare/70920b4812a9d6bb3a2727cb6295da72518cde6f...3102858ac2190a059ad4bf4ede888da092ce9c90).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>